### PR TITLE
Dependencies upper bounds

### DIFF
--- a/network-transport-tests.cabal
+++ b/network-transport-tests.cabal
@@ -28,7 +28,7 @@ library
                        bytestring >= 0.9 && < 0.11,
                        random >= 1.0 && < 1.1,
                        mtl >= 2.1 && < 2.2,
-                       ansi-terminal >= 0.5 && < 0.6
+                       ansi-terminal >= 0.5 && < 0.7
   hs-source-dirs:      src
   ghc-options:         -Wall -fno-warn-unused-do-bind
   extensions:          CPP,


### PR DESCRIPTION
Bump base for compatibility with GHC 7.8. Also bump ansi-terminal, for broader compatibility.
