### PR TITLE
network-transport-tests.cabal: allow random-1.1

### DIFF
--- a/network-transport-tests.cabal
+++ b/network-transport-tests.cabal
@@ -26,7 +26,7 @@ library
                        network-transport >= 0.4.1.0 && < 0.5,
                        containers >= 0.4 && < 0.6,
                        bytestring >= 0.9 && < 0.11,
-                       random >= 1.0 && < 1.1,
+                       random >= 1.0 && < 1.2,
                        mtl >= 2.1 && < 2.3,
                        ansi-terminal >= 0.5 && < 0.7
   hs-source-dirs:      src


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich <siarheit@google.com>