### PR TITLE
Bump version to 0.2.4.0

### DIFF
--- a/network-transport-tests.cabal
+++ b/network-transport-tests.cabal
@@ -1,5 +1,5 @@
 name:                network-transport-tests
-version:             0.2.3.0
+version:             0.2.4.0
 synopsis:            Unit tests for Network.Transport implementations
 -- description:
 homepage:            http://haskell-distributed.github.com


### PR DESCRIPTION
Previous release demands network-transport < 0.5, but there are
network-transport 0.5 and 0.5.1 releases on hackage.