### PR TITLE
testCloseConnect synchronization

### DIFF
--- a/src/Network/Transport/Tests.hs
+++ b/src/Network/Transport/Tests.hs
@@ -661,6 +661,7 @@ testCloseEndPoint transport _ = do
       close conn
       putMVar serverFirstTestDone ()
       ConnectionClosed cid' <- receive endpoint ; True <- return $ cid == cid'
+      putMVar serverAddr (address endpoint)
       return ()
 
     -- Second test
@@ -687,10 +688,10 @@ testCloseEndPoint transport _ = do
 
   -- Client
   forkTry $ do
-    theirAddr <- readMVar serverAddr
 
     -- First test: close endpoint with one outgoing but no incoming connections
     do
+      theirAddr <- takeMVar serverAddr
       Right endpoint <- newEndPoint transport
       putMVar clientAddr1 (address endpoint)
 
@@ -707,6 +708,7 @@ testCloseEndPoint transport _ = do
 
     -- Second test: close endpoint with one outgoing and one incoming connection
     do
+      theirAddr <- takeMVar serverAddr
       Right endpoint <- newEndPoint transport
       putMVar clientAddr2 (address endpoint)
 


### PR DESCRIPTION
When the server receives on line 663, we expect the connection closed
event from the first client to come through as a result of line 705
(closeEndPoint). But immediately after the closeEndPoint, a new endpoint
was created and a new connection made from that endpoint to the server.
It was possible that the server would receive the connection opened
event from the second endpoint before the connection closed event from
the first endpoint. But now it's not: the second client waits on the
serverAddr MVar which won't be filled until the connection closed event
is dequeued.